### PR TITLE
Allow registrations to be manifested on the file system

### DIFF
--- a/lib/synapse/file_output.rb
+++ b/lib/synapse/file_output.rb
@@ -1,0 +1,53 @@
+require 'synapse/log'
+require 'fileutils'
+require 'tempfile'
+
+module Synapse
+  class FileOutput
+    include Logging
+    attr_reader :opts, :name
+
+    def initialize(opts)
+      super()
+
+      unless opts.has_key?("output_directory")
+        raise ArgumentError, "flat file generation requires an output_directory key"
+      end
+
+      begin
+        FileUtils.mkdir_p(opts['output_directory'])
+      rescue SystemCallError => err
+        raise ArgumentError, "provided output directory #{opts['output_directory']} is not present or creatable"
+      end
+
+      @opts = opts
+      @name = 'file_output'
+    end
+
+    def update_config(watchers)
+      watchers.each do |watcher|
+        write_backends_to_file(watcher.name, watcher.backends)
+      end
+    end
+
+    def write_backends_to_file(service_name, new_backends)
+      data_path = File.join(@opts['output_directory'], "#{service_name}.json")
+      begin
+        old_backends = JSON.load(File.read(data_path))
+      rescue Errno::ENOENT
+        old_backends = nil
+      end
+
+      if old_backends == new_backends
+        return false
+      else
+        # Atomically write new sevice configuration file
+        temp_path = File.join(@opts['output_directory'],
+                              ".#{service_name}.json.tmp")
+        File.open(temp_path, 'w', 0644) {|f| f.write(new_backends.to_json)}
+        FileUtils.mv(temp_path, data_path)
+        return true
+      end
+    end
+  end
+end

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -4,7 +4,7 @@ require 'socket'
 module Synapse
   class Haproxy
     include Logging
-    attr_reader :opts
+    attr_reader :opts, :name
 
     # these come from the documentation for haproxy 1.5
     # http://haproxy.1wt.eu/download/1.5/doc/configuration.txt
@@ -523,6 +523,7 @@ module Synapse
       end
 
       @opts = opts
+      @name = 'haproxy'
 
       # how to restart haproxy
       @restart_interval = 2


### PR DESCRIPTION
If the configuration specifies a flat_file key, synapse will manifest
and update registrations on the filesystem in an atomic way.
This is useful for applications that do not wish to communicate with
service backends via haproxy
