### PR TITLE
Rate limit restarts but not stats socket updates

### DIFF
--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -57,11 +57,14 @@ module Synapse
         if @config_updated
           @config_updated = false
           @config_generators.each do |config_generator|
-            log.info "synapse: regenerating #{config_generator.name} config"
+            log.info "synapse: configuring #{config_generator.name}"
             config_generator.update_config(@service_watchers)
           end
-        else
-          sleep 1
+        end
+
+        sleep 1
+        @config_generators.each do |config_generator|
+          config_generator.tick(@service_watchers)
         end
 
         loops += 1

--- a/lib/synapse/file_output.rb
+++ b/lib/synapse/file_output.rb
@@ -24,6 +24,9 @@ module Synapse
       @name = 'file_output'
     end
 
+    def tick(watchers)
+    end
+
     def update_config(watchers)
       watchers.each do |watcher|
         write_backends_to_file(watcher.name, watcher.backends)


### PR DESCRIPTION
We can allow socket updates to go through any time that the config was
updated, but restarts must be rate limited for stability
