### PR TITLE
Try out :per_callback threads and get more debug information

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,11 +62,11 @@ GEM
     slyphon-zookeeper_jar (3.3.5-java)
     spoon (0.0.4)
       ffi
-    zk (1.9.4)
+    zk (1.9.5)
       logging (~> 1.8.2)
       zookeeper (~> 1.4.0)
-    zookeeper (1.4.8)
-    zookeeper (1.4.8-java)
+    zookeeper (1.4.10)
+    zookeeper (1.4.10-java)
       slyphon-log4j (= 1.2.15)
       slyphon-zookeeper_jar (= 3.3.5)
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ The `haproxy` section of the config file has the following options:
 * `config_file_path`: where Synapse will write the HAProxy config file
 * `do_writes`: whether or not the config file will be written (default to `true`)
 * `do_reloads`: whether or not Synapse will reload HAProxy (default to `true`)
+* `do_socket`: whether or not Synapse will use the HAProxy socket commands to prevent reloads (default to `true`)
 * `global`: options listed here will be written into the `global` section of the HAProxy config
 * `defaults`: options listed here will be written into the `defaults` section of the HAProxy config
 * `extra_sections`: additional, manually-configured `frontend`, `backend`, or `listen` stanzas

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -530,6 +530,10 @@ module Synapse
       @opts = opts
       @name = 'haproxy'
 
+      @opts['do_writes'] = true unless @opts.key?('do_writes')
+      @opts['do_socket'] = true unless @opts.key?('do_socket')
+      @opts['do_reloads'] = true unless @opts.key?('do_reloads')
+
       # how to restart haproxy
       @restart_interval = @opts.fetch('restart_interval', 2).to_i
       @restart_jitter = @opts.fetch('restart_jitter', 0).to_f

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -80,6 +80,7 @@ module Synapse
     # sets up zookeeper callbacks if the data at the discovery path changes
     def watch
       return if @zk.nil?
+      log.debug "synapse: setting watch at #{@discovery['path']}"
 
       @watcher.unsubscribe unless @watcher.nil?
       @watcher = @zk.register(@discovery['path'], &watcher_callback)
@@ -89,6 +90,7 @@ module Synapse
         log.error "synapse: zookeeper watcher path #{@discovery['path']} does not exist!"
         raise RuntimeError.new('could not set a ZK watch on a node that should exist')
       end
+      log.debug "synapse: set watch at #{@discovery['path']}"
     end
 
     # handles the event that a watched path has changed in zookeeper
@@ -134,7 +136,7 @@ module Synapse
       @@zk_pool_lock.synchronize {
         unless @@zk_pool.has_key?(@zk_hosts)
           log.info "synapse: creating pooled connection to #{@zk_hosts}"
-          @@zk_pool[@zk_hosts] = ZK.new(@zk_hosts, :timeout => 5)
+          @@zk_pool[@zk_hosts] = ZK.new(@zk_hosts, :timeout => 5, :thread => :per_callback)
           @@zk_pool_count[@zk_hosts] = 1
           log.info "synapse: successfully created zk connection to #{@zk_hosts}"
         else


### PR DESCRIPTION
We are experiencing some very slow updates in production and I think it
may be due to the connection pooling, try :per_callback threading to see
if that helps.

Also fixes default values for do_writes, do_reloads, do_socket
